### PR TITLE
Tighten Profile 7 wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the hard formats behave like ordinary video.
 
 ### Real-time Dolby Vision Profile 7 → Profile 8.1
 
-Android TV can convert a Dolby Vision Profile-7 Blu-ray remux into Profile 8.1
+Android TV can convert a Dolby Vision Profile-7 MKV into Profile 8.1
 **on the box, while it plays**. This is NAL-level bitstream surgery, not a video
 transcode:
 


### PR DESCRIPTION
## What changed

Replace one source-format phrase with the neutral `Profile-7 MKV` wording.

## Why

Keeps the release README aligned with Sipario's user-supplied-source positioning while preserving the technical P7 → P8.1 explanation.

## Validation

- banned marketing vocabulary scan passed
- README auto-generated release markers remain untouched